### PR TITLE
This improves drastically overthreading issue (>48cores)

### DIFF
--- a/gemm-common/src/gemm.rs
+++ b/gemm-common/src/gemm.rs
@@ -97,7 +97,7 @@ impl Conj for c64 {
     }
 }
 
-pub const DEFAULT_THREADING_THRESHOLD: usize = 64 * 64 * 256;
+pub const DEFAULT_THREADING_THRESHOLD: usize = 48 * 48 * 256;
 pub const DEFAULT_RHS_PACKING_THRESHOLD: usize = 128;
 pub const DEFAULT_LHS_PACKING_THRESHOLD_SINGLE_THREAD: usize = 8;
 pub const DEFAULT_LHS_PACKING_THRESHOLD_MULTI_THREAD: usize = 16;

--- a/gemm-common/src/gemm.rs
+++ b/gemm-common/src/gemm.rs
@@ -348,7 +348,7 @@ pub unsafe fn gemm_basic_generic<
                 Parallelism::Rayon(max_threads) => {
                     let threading_threshold = get_threading_threshold();
 
-                    let max_threads = if n_threads == 0 {
+                    let max_threads = if max_threads == 0 {
                         rayon::current_num_threads()
                     } else {
                         max_threads

--- a/gemm/Cargo.toml
+++ b/gemm/Cargo.toml
@@ -37,6 +37,7 @@ rand = "0.8.5"
 nalgebra = "0.32.2"
 assert_approx_eq = "1.1.0"
 rayon = "1.7"
+num_cpus = "1.16.0"
 
 [[bench]]
 name = "bench"

--- a/gemm/benches/bench.rs
+++ b/gemm/benches/bench.rs
@@ -256,6 +256,112 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     }
 }
 
+pub fn criterion_benchmark_parallelism(c: &mut Criterion) {
+    let mnks = vec![(6, 768 * 3, 768)];
+    // let mut push = |m, n, k| {
+    //     mnks.push((m, n, k));
+    // };
+    // push(64, 64, 64);
+    // push(8192, 8192, 8192);
+    // push(4096, 4096, 4096);
+    // push(1024, 1024, 1024);
+    // push(896, 128, 128);
+    // push(512, 256, 256);
+    // push(448, 448, 128);
+    // push(256, 256, 256);
+    // push(256, 32, 256);
+    // push(52, 52, 256);
+    // push(48, 48, 256);
+    // push(63, 1, 10);
+    // push(63, 2, 10);
+    // push(63, 3, 10);
+    // push(63, 4, 10);
+
+    // push(1024, 1, 1024);
+    // push(1024, 2, 1024);
+    // push(1024, 3, 1024);
+    // push(1024, 4, 1024);
+    //
+    let n_cpus = num_cpus::get();
+
+    for (m, n, k) in mnks.iter().copied() {
+        let a_vec = vec![0.0_f32; m * k];
+        let b_vec = vec![0.0_f32; k * n];
+        let mut c_vec = vec![0.0_f32; m * n];
+
+        for (dst_label, dst_cs, dst_rs) in [("n", m, 1), ("t", 1, n)] {
+            for (lhs_label, lhs_cs, lhs_rs) in [("n", m, 1), ("t", 1, k)] {
+                for (rhs_label, rhs_cs, rhs_rs) in [("n", k, 1), ("t", 1, n)] {
+                    c.bench_function(
+                        &format!(
+                            "parallelism-{}-f32-{}{}{}-gemm-{}×{}×{}",
+                            n_cpus, dst_label, lhs_label, rhs_label, m, n, k
+                        ),
+                        |b| {
+                            b.iter(|| unsafe {
+                                gemm(
+                                    m,
+                                    n,
+                                    k,
+                                    c_vec.as_mut_ptr(),
+                                    dst_cs as isize,
+                                    dst_rs as isize,
+                                    true,
+                                    a_vec.as_ptr(),
+                                    lhs_cs as isize,
+                                    lhs_rs as isize,
+                                    b_vec.as_ptr(),
+                                    rhs_cs as isize,
+                                    rhs_rs as isize,
+                                    0.0_f32,
+                                    0.0_f32,
+                                    false,
+                                    false,
+                                    false,
+                                    gemm::Parallelism::Rayon(n_cpus),
+                                )
+                            })
+                        },
+                    );
+                    c.bench_function(
+                        &format!(
+                            "parallelism-none-f32-{}{}{}-gemm-{}×{}×{}",
+                            dst_label, lhs_label, rhs_label, m, n, k
+                        ),
+                        |b| {
+                            b.iter(|| unsafe {
+                                gemm(
+                                    m,
+                                    n,
+                                    k,
+                                    c_vec.as_mut_ptr(),
+                                    dst_cs as isize,
+                                    dst_rs as isize,
+                                    true,
+                                    a_vec.as_ptr(),
+                                    lhs_cs as isize,
+                                    lhs_rs as isize,
+                                    b_vec.as_ptr(),
+                                    rhs_cs as isize,
+                                    rhs_rs as isize,
+                                    0.0_f32,
+                                    0.0_f32,
+                                    false,
+                                    false,
+                                    false,
+                                    gemm::Parallelism::None,
+                                )
+                            })
+                        },
+                    );
+                }
+            }
+        }
+
+    }
+
+}
+
 criterion_group!(
     name = benches;
     config = Criterion::default()
@@ -264,4 +370,12 @@ criterion_group!(
         .sample_size(10);
     targets = criterion_benchmark
 );
-criterion_main!(benches);
+criterion_group!(
+    name = benches_parallelism;
+    config = Criterion::default()
+        .warm_up_time(Duration::from_secs(1))
+        .measurement_time(Duration::from_secs(2))
+        .sample_size(10);
+    targets = criterion_benchmark_parallelism
+);
+criterion_main!(benches, benches_parallelism);


### PR DESCRIPTION
I'm not sure that this change is optimal by any means.

But it does yield a significant improvement when running relatively small matmul over a 48 core machine.

Before:
```
// 48 cores
parallelism-48-f32-nnn-gemm-6×2304×768
                        time:   [2.2215 ms 2.2584 ms 2.2906 ms]
                        change: [-2.7095% -0.4486% +2.0755%] (p = 0.74 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild

parallelism-none-f32-nnn-gemm-6×2304×768
                        time:   [745.65 µs 746.78 µs 748.09 µs]
                        change: [-0.6916% -0.4244% -0.1303%] (p = 0.02 < 0.05)
                        Change within noise threshold.
```

After:
```
parallelism-48-f32-nnn-gemm-6×2304×768
                        time:   [641.83 µs 651.66 µs 664.90 µs]
                        change: [-71.903% -71.301% -70.685%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe

parallelism-none-f32-nnn-gemm-6×2304×768
                        time:   [741.77 µs 744.47 µs 748.39 µs]
                        change: [-0.9774% -0.6209% -0.2174%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
```

At least we're not slowing down drastically (but this is not an improvement either)