### PR TITLE
Update `diol` dependency

### DIFF
--- a/gemm/Cargo.toml
+++ b/gemm/Cargo.toml
@@ -69,10 +69,11 @@ criterion = { version = "0.5", default-features = false }
 nalgebra = "0.32.2"
 assert_approx_eq = "1.1.0"
 rand = "0.8.5"
-diol = "0.2.0"
+diol = "0.8.3"
 clap = { version = "4.5.4", features = ["derive"] }
 aligned-vec = "0.5.0"
 itertools = "0.12.1"
+regex = "1.10.4"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 getrandom = { version = "0.2", features = ["js"] }

--- a/gemm/benches/bench.rs
+++ b/gemm/benches/bench.rs
@@ -1,9 +1,13 @@
 use std::time::Duration;
 
 use aligned_vec::{avec, AVec};
-use diol::prelude::*;
+use diol::{
+    config::{MaxTime, MinTime},
+    prelude::*,
+};
 use gemm::*;
 use num_traits::One;
+use regex::Regex;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 enum Layout {
@@ -34,7 +38,7 @@ fn make_data<T: Copy + One>(
 
 fn bench_gemm<T: One + Copy + 'static>(
     bencher: Bencher,
-    unlist![par, dst, lhs, rhs, m, n, k]: List![
+    list![par, dst, lhs, rhs, m, n, k]: List![
         Parallelism,
         Layout,
         Layout,
@@ -115,10 +119,10 @@ fn main() {
     let clap = Clap::parse();
     let mut config = BenchConfig::default();
     if let Some(name) = &clap.name {
-        config.fn_regex = Some(Regex::new(name).unwrap());
+        config.func_filter = Some(Regex::new(name).unwrap());
     }
     if let Some(arg) = &clap.arg {
-        config.arg_regex = Some(Regex::new(arg).unwrap());
+        config.arg_filter = Some(Regex::new(arg).unwrap());
     }
     config.min_time = MinTime(Duration::from_secs(1));
     config.max_time = MaxTime(Duration::from_secs(1));
@@ -133,7 +137,7 @@ fn main() {
 
         for modifier in modifiers {
             gemm::set_threading_threshold(gemm::DEFAULT_THREADING_THRESHOLD / modifier);
-            bench.run();
+            bench.run().unwrap();
         }
     }
     {
@@ -141,7 +145,7 @@ fn main() {
         bench.register(bench_gemm::<f64>, args());
         for modifier in modifiers {
             gemm::set_threading_threshold(gemm::DEFAULT_THREADING_THRESHOLD / modifier);
-            bench.run();
+            bench.run().unwrap();
         }
     }
     {
@@ -149,7 +153,7 @@ fn main() {
         bench.register(bench_gemm::<c32>, args());
         for modifier in modifiers {
             gemm::set_threading_threshold(gemm::DEFAULT_THREADING_THRESHOLD / modifier);
-            bench.run();
+            bench.run().unwrap();
         }
     }
     {
@@ -157,7 +161,7 @@ fn main() {
         bench.register(bench_gemm::<c64>, args());
         for modifier in modifiers {
             gemm::set_threading_threshold(gemm::DEFAULT_THREADING_THRESHOLD / modifier);
-            bench.run();
+            bench.run().unwrap();
         }
     }
 }


### PR DESCRIPTION
While just poking around, I stumbled across this repository and tried to run the benchmarks. It failed due to a `fontconfig` issue which I tracked down to the `diol` dependency. In more recent times, `diol` has gained a `plot` feature that I was able to turn off to get things to run. In doing so, I upgraded `diol` to its latest version and thought to upstream it--this PR. Feel free to take it or leave it or change it as you see fit!