### PR TITLE
Don't crash on Linux machines with L4 cache

### DIFF
--- a/gemm-common/src/cache.rs
+++ b/gemm-common/src/cache.rs
@@ -203,7 +203,7 @@ fn cache_info() -> Option<[CacheInfo; 3]> {
                             if level == 3 {
                                 shared_count = 1;
                             }
-                            if level > 0 {
+                            if level > 0 && level < 4 {
                                 if cache_info.cache_line_bytes
                                     >= all_info[level - 1].cache_line_bytes
                                 {


### PR DESCRIPTION
I recently found out that [this is a thing](https://en.wikichip.org/wiki/intel/crystal_well) when trying to run a `candle` program (which depends on `gemm`) on this machine:

```
# grep 'model name' /proc/cpuinfo
model name      : Intel(R) Core(TM) i7-4770R CPU @ 3.20GHz
...
# cat /sys/devices/system/cpu/cpu*/cache/index4/level
4
...
# lscpu -B -C=type,level,ways,coherency-size,one-size
TYPE        LEVEL WAYS COHERENCY-SIZE  ONE-SIZE
Data            1    8             64     32768
Instruction     1    8             64     32768
Unified         2    8             64    262144
Unified         3   12             64   6291456
Unified         4   16             64 134217728
```

The Linux-specific code path that probes cache sizes via `lscpu` and `sysfs` assumes that `level` can't be greater than 3, so without this PR anything using `gemm` crashes like this:
```
index out of bounds: the len is 3 but the index is 3
```

This PR fixes this by adding a guard identical to the [one existing](https://github.com/sarah-ek/gemm/blob/8cdc1de4af69ce3fd2575b2c983fc1ccc974425f/gemm-common/src/cache.rs#L323) in the generic X86 cache size probing code.

(an interesting theoretical question is whether it is possible to somehow exploit this gigantic 128 MiB cache instead of ignoring it)